### PR TITLE
disable `futures` default features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ categories = ["asynchronous", "concurrency"]
 keywords = ["futures", "async", "stream", "progress", "notify"]
 
 [dependencies]
-futures = "0.3"
+futures = { version = "0.3", default-features = false, features = ["std"] }
 pin-project-lite = "0.2"
 
 [dev-dependencies]


### PR DESCRIPTION
This avoids the need to pull in some extra `futures` dependencies in upstream projects, e.g. `futures-executor`. This saves 8 dependencies:

before:
```
sipper v0.1.0 (/home/edwin/git/sipper)
├── futures v0.3.31
│   ├── futures-channel v0.3.31
│   │   ├── futures-core v0.3.31
│   │   └── futures-sink v0.3.31
│   ├── futures-core v0.3.31
│   ├── futures-executor v0.3.31
│   │   ├── futures-core v0.3.31
│   │   ├── futures-task v0.3.31
│   │   └── futures-util v0.3.31
│   │       ├── futures-channel v0.3.31 (*)
│   │       ├── futures-core v0.3.31
│   │       ├── futures-io v0.3.31
│   │       ├── futures-macro v0.3.31 (proc-macro)
│   │       │   ├── proc-macro2 v1.0.94
│   │       │   │   └── unicode-ident v1.0.18
│   │       │   ├── quote v1.0.40
│   │       │   │   └── proc-macro2 v1.0.94 (*)
│   │       │   └── syn v2.0.100
│   │       │       ├── proc-macro2 v1.0.94 (*)
│   │       │       ├── quote v1.0.40 (*)
│   │       │       └── unicode-ident v1.0.18
│   │       ├── futures-sink v0.3.31
│   │       ├── futures-task v0.3.31
│   │       ├── memchr v2.7.4
│   │       ├── pin-project-lite v0.2.16
│   │       ├── pin-utils v0.1.0
│   │       └── slab v0.4.9
│   │           [build-dependencies]
│   │           └── autocfg v1.4.0
│   ├── futures-io v0.3.31
│   ├── futures-sink v0.3.31
│   ├── futures-task v0.3.31
│   └── futures-util v0.3.31 (*)
└── pin-project-lite v0.2.16
[dev-dependencies]
└── tokio v1.44.1
    ├── pin-project-lite v0.2.16
    └── tokio-macros v2.5.0 (proc-macro)
        ├── proc-macro2 v1.0.94 (*)
        ├── quote v1.0.40 (*)
        └── syn v2.0.100 (*)
```

after:
```
sipper v0.1.0 (/home/edwin/git/sipper)
├── futures v0.3.31
│   ├── futures-channel v0.3.31
│   │   ├── futures-core v0.3.31
│   │   └── futures-sink v0.3.31
│   ├── futures-core v0.3.31
│   ├── futures-io v0.3.31
│   ├── futures-sink v0.3.31
│   ├── futures-task v0.3.31
│   └── futures-util v0.3.31
│       ├── futures-channel v0.3.31 (*)
│       ├── futures-core v0.3.31
│       ├── futures-io v0.3.31
│       ├── futures-sink v0.3.31
│       ├── futures-task v0.3.31
│       ├── memchr v2.7.4
│       ├── pin-project-lite v0.2.16
│       ├── pin-utils v0.1.0
│       └── slab v0.4.9
│           [build-dependencies]
│           └── autocfg v1.4.0
└── pin-project-lite v0.2.16
[dev-dependencies]
└── tokio v1.44.1
    ├── pin-project-lite v0.2.16
    └── tokio-macros v2.5.0 (proc-macro)
        ├── proc-macro2 v1.0.94
        │   └── unicode-ident v1.0.18
        ├── quote v1.0.40
        │   └── proc-macro2 v1.0.94 (*)
        └── syn v2.0.100
            ├── proc-macro2 v1.0.94 (*)
            ├── quote v1.0.40 (*)
            └── unicode-ident v1.0.18
```